### PR TITLE
Jack suggesting logging the error versus displaying, implemented.

### DIFF
--- a/src/reference/DefaultSecurityConfiguration.php
+++ b/src/reference/DefaultSecurityConfiguration.php
@@ -207,7 +207,7 @@ class DefaultSecurityConfiguration implements SecurityConfiguration
      */
     private function _logSpecial($msg)
     {
-        echo $msg;
+        ESAPI::getAuditor('DefaultSecurityConfiguration')->warning(Auditor::SECURITY, false, $msg);
     }
 
     /**


### PR DESCRIPTION
http://jackwillk.blogspot.com/2010/07/using-owasp-php-esapi-part-2.html

I'll be pulling my repo for upcoming project(s) because I agree (until the merge). I'd rather see my errors in the logs.

I did not implement the rest of the changes for modifying the objects and methods otherwise. From the user's perspective, silently failing code is my preference-- I validate on the front end, so data entry issues for the user should be caught there. If issues are not caught and there are problems, I can check the logs. At this point something has gone fairly wrong and I'd rather not clue the user or hacker in on it.
