### PR TITLE
[bugfix] Return array instead of boolean (fixes #3)

### DIFF
--- a/src/StringUtilities.php
+++ b/src/StringUtilities.php
@@ -83,7 +83,11 @@ class StringUtilities
             return null;
         }
 
-        return sort(array_unique(array_merge($c1, $c2)));
+        $result = array_unique(array_merge($c1, $c2));
+
+        sort($result);
+
+        return $result;
     }
 
 


### PR DESCRIPTION
This also fixes the 'Only variables should be passed by reference' error in the unit tests
